### PR TITLE
增加了数据库操作函数

### DIFF
--- a/_lp/core/lib/db.function.php
+++ b/_lp/core/lib/db.function.php
@@ -158,4 +158,98 @@ function close_db( $db = NULL )
 	mysql_close( $db );
 }
 
+// ==================================================================
+//
+// 插入数据
+//
+// ------------------------------------------------------------------
+
+
+function db_insert($table,$data,$replace=false){
+	if(is_string($data)){
+		$data=db_create($data);
+	}
+	$keys=array_keys($data);
+	$values=array_values($data);
+	$values=array_map('s', $values);//安全过滤
+	$type=$replace?'REPLACE':'INSERT';
+	return run_sql("{$type} INTO `{$table}`(`".implode("`,`", $keys)."`) VALUES('".implode("','", $values)."')");
+}
+
+// ==================================================================
+//
+// 更新数据
+//
+// ------------------------------------------------------------------
+
+function db_update($table,$data,$where){
+	if(is_string($data)){
+		$data=db_create($data);
+	}
+	$fields=array();
+	foreach($data as $key=>$value){
+		$fields[]="`{$key}`='".s($value)."'";//安全过滤
+	}
+	return run_sql("UPDATE `{$table}` SET ".implode(',', $fields)." WHERE {$where}");
+}
+
+// ==================================================================
+//
+// 创建数据
+// $data的格式：
+// field1,field2,field3
+// or
+// fiedl1,field2,field3:fun // 使用过滤函数过滤
+// or
+// field1,^field2,field3|fun,filed4:fun
+// or
+//！field1,field2,filed3:fun
+//
+// ------------------------------------------------------------------
+
+function db_create($data){
+	//判断是否为非模式，字符串以！开头
+	if('!'==substr($data, 0,1)){
+		$not=true;
+		//如果为非模式，去掉开头的！
+		$data=substr($data,1);
+	}else{
+		$not=false;
+	}
+	$field_filter=explode(':', $data);
+	//提取字段
+	$fields=explode(',', $field_filter[0]);
+	//提取过滤函数
+	$filter=isset($field_filter[1])?$field_filter[1]:false;
+	$postData=$_POST;
+	if($not){//非模式的处理
+		foreach ($fields as $field ){
+			unset($postData[$field]);
+		}
+		if($filter) $postData=array_map($filter, $postData);
+		return $postData;
+	}
+	$result=array();
+	//循环字段
+	foreach ($fields as $field) {
+		$not_filter=false;
+		//字段如以^开头，不进行过滤函数过滤。
+		if('^'==substr($field, 0,1)){
+			$not_filter=true;
+			$field=substr($field, 1);
+		}
+		//字段如果有|隔开一个函数名还需要用单独的过滤函数过滤
+		$field_single=explode('|', $field);
+		$field=$field_single[0];
+		$single_filter=isset($field_single[1])?$field_single[1]:false;
+		//数据过滤
+		if($single_filter) $postData[$field]=$single_filter($postData[$field]);
+		if($filter) $postData[$field]=$filter($postData[$field]);
+		//加入result
+		$result[$field]=$postData[$field];
+	}
+	return $result;
+	
+}
+
 ?>

--- a/_lp/core/lib/db.sae.function.php
+++ b/_lp/core/lib/db.sae.function.php
@@ -200,4 +200,98 @@ function close_db( $db = NULL )
 	mysql_close( $db );
 }
 
+// ==================================================================
+//
+// 插入数据
+//
+// ------------------------------------------------------------------
+
+
+function db_insert($table,$data,$replace=false){
+	if(is_string($data)){
+		$data=db_create($data);
+	}
+	$keys=array_keys($data);
+	$values=array_values($data);
+	$values=array_map('s', $values);//安全过滤
+	$type=$replace?'REPLACE':'INSERT';
+	return run_sql("{$type} INTO `{$table}`(`".implode("`,`", $keys)."`) VALUES('".implode("','", $values)."')");
+}
+
+// ==================================================================
+//
+// 更新数据
+//
+// ------------------------------------------------------------------
+
+function db_update($table,$data,$where){
+	if(is_string($data)){
+		$data=db_create($data);
+	}
+	$fields=array();
+	foreach($data as $key=>$value){
+		$fields[]="`{$key}`='".s($value)."'";//安全过滤
+	}
+	return run_sql("UPDATE `{$table}` SET ".implode(',', $fields)." WHERE {$where}");
+}
+
+// ==================================================================
+//
+// 创建数据
+// $data的格式：
+// field1,field2,field3
+// or
+// fiedl1,field2,field3:fun // 使用过滤函数过滤
+// or
+// field1,^field2,field3|fun,filed4:fun
+// or
+//！field1,field2,filed3:fun
+//
+// ------------------------------------------------------------------
+
+function db_create($data){
+	//判断是否为非模式，字符串以！开头
+	if('!'==substr($data, 0,1)){
+		$not=true;
+		//如果为非模式，去掉开头的！
+		$data=substr($data,1);
+	}else{
+		$not=false;
+	}
+	$field_filter=explode(':', $data);
+	//提取字段
+	$fields=explode(',', $field_filter[0]);
+	//提取过滤函数
+	$filter=isset($field_filter[1])?$field_filter[1]:false;
+	$postData=$_POST;
+	if($not){//非模式的处理
+		foreach ($fields as $field ){
+			unset($postData[$field]);
+		}
+		if($filter) $postData=array_map($filter, $postData);
+		return $postData;
+	}
+	$result=array();
+	//循环字段
+	foreach ($fields as $field) {
+		$not_filter=false;
+		//字段如以^开头，不进行过滤函数过滤。
+		if('^'==substr($field, 0,1)){
+			$not_filter=true;
+			$field=substr($field, 1);
+		}
+		//字段如果有|隔开一个函数名还需要用单独的过滤函数过滤
+		$field_single=explode('|', $field);
+		$field=$field_single[0];
+		$single_filter=isset($field_single[1])?$field_single[1]:false;
+		//数据过滤
+		if($single_filter) $postData[$field]=$single_filter($postData[$field]);
+		if($filter) $postData[$field]=$filter($postData[$field]);
+		//加入result
+		$result[$field]=$postData[$field];
+	}
+	return $result;
+	
+}
+
 ?>


### PR DESCRIPTION
1，    添加数据： 在db.function.php文件中增加了db_insert函数， 方便我们进行数据插入操作。db_insert有三参数： db_insert($table,$data,$replace=false);
table:要插入的表
data:插入的数据，可以是数组或字符串
replace: 默认为false，以insert into方式插入，如果为true则以replace into的方式插入。
使用举例：
$setarr=array(
‘key1’=>v(‘key1’),
‘key2’=>v(‘key2’)
);
db_insert(‘table’,$setarr);
当data为数组是，数组的下标对应数据表中的字段名称，数组的值对应数据表字段的值。数据插入前不需要用s函数对数据进行过滤， db_insert 函数内部已经自动对数据进行了安全过滤。
我们还可以写得更简单：
db_insert(‘table’,’key1,key2’);
当data是字符串时。 用逗号隔开需要插入的字段。此时db_insert函数内部会自动获得表单中的数据，这样使用时，需要注意表单中文本域的name值要和数据表中的字段名称一致。
如果想提交的数据使用指定函数过滤：
db_insert(‘table’,’key1,key2:filter’); 。表示key1，key2的数据都会被filter函数过滤。在字符串的最后用冒号+函数名表示过滤函数， 这样的过滤函数会作用在所有字段上。 ，如果想某个字段不被过滤函数过滤：
db_insert(‘table’,’key1,^key2,key3:filter’); 。 在字段名称前加上^ 符号，表示这个字段数据不被过滤函数过滤。 
你还可以给每个字段单独定义过滤函数
db_insert(‘table’,’key1|fun1,key2|fun2,key3|fun3’);
    在每个字段的后面用 竖线加上函数名的形式表示定义单独的过滤函数， 上面的代码表示， key1用fun1过滤，key2用fun2过滤， key3用fun3过滤。
一个复杂点的例子：
db_insert(‘table’,’key1|fun1,^key2|fun2,key3|fun3:filter’);
表示 key1和key3都会被fun1和filte过滤；key2不被filter过滤，用fun2过滤；

还可以这样使用：
db_insert(‘table’,’!key1,key2’); 表示提交的表单中，除了key1和key2，其他字段都存入数据库。
同样也可以定义过滤函数： db_insert(‘table’,’!key1,key2:filter’); 所有存入的数据都会被filter函数过滤。

2，    修改数据， 在db.function.php中增加了 db_update函数，方便我们进行更新数据。它有三个参数。
db_update($table,$data,$where);
table：要更新的数据表
data：要更新的数据
where：更新条件
其中table和data参数的用法和db_insert一样，这里不再做多余的说明。
使用实例：
db_update(‘table’,’key1,key2’,’where id=1’);
